### PR TITLE
macros/actions/python.yml: Use correct python deps

### DIFF
--- a/data/macros/actions/python.yml
+++ b/data/macros/actions/python.yml
@@ -21,6 +21,7 @@ actions:
             python3 -m build --wheel --no-isolation
         dependencies:
             - python-build
+            - python-wheel
 
     # Install wheel to destination directory
     - pyproject_install:

--- a/data/macros/actions/python.yml
+++ b/data/macros/actions/python.yml
@@ -20,11 +20,11 @@ actions:
         command: |
             python3 -m build --wheel --no-isolation
         dependencies:
-            - python
+            - python-build
 
     # Install wheel to destination directory
     - pyproject_install:
         command: |
             python3 -m installer --destdir="%(installroot)" dist/*.whl
         dependencies:
-            - python
+            - python-installer


### PR DESCRIPTION
Depends on:

- [python-build](https://github.com/snekpit/venom/tree/f01e9e7bfb136067d2abe1b7140c6ca8ec3d6398/lang/python/python-build)
- [python-installer](https://github.com/snekpit/venom/tree/f01e9e7bfb136067d2abe1b7140c6ca8ec3d6398/lang/python/python-installer)
- [python-wheel](https://github.com/snekpit/venom/tree/f01e9e7bfb136067d2abe1b7140c6ca8ec3d6398/lang/python/python-wheel)

These packages and their dependencies must be ported to snekpit/main for this PR to work.