### PR TITLE
boulder: make cache paths public

### DIFF
--- a/source/boulder/buildjob.d
+++ b/source/boulder/buildjob.d
@@ -22,6 +22,22 @@ import std.array : join;
 
 immutable static private auto SharedRootBase = "/var/cache/boulder";
 
+immutable static public auto SharedRootArtefactsCache = join([
+    SharedRootBase, "artefacts"
+], "/");
+immutable static public auto SharedRootBuildCache = join([
+    SharedRootBase, "build"
+], "/");
+immutable static public auto SharedRootCcacheCache = join([
+    SharedRootBase, "ccache"
+], "/");
+immutable static public auto SharedRootPkgCacheCache = join([
+    SharedRootBase, "pkgCache"
+], "/");
+immutable static public auto SharedRootRootCache = join([
+    SharedRootBase, "root"
+], "/");
+
 package struct BuildPaths
 {
     /**
@@ -71,17 +87,17 @@ public final class BuildJob
         auto subpath = format!"%s-%s-%s"(_recipe.source.name,
                 _recipe.source.versionIdentifier, _recipe.source.release);
         /* Output */
-        _hostPaths.artefacts = join([SharedRootBase, "artefacts", subpath], "/");
+        _hostPaths.artefacts = join([SharedRootArtefactsCache, subpath], "/");
         /* Where to build */
-        _hostPaths.buildRoot = join([SharedRootBase, "build", subpath], "/");
+        _hostPaths.buildRoot = join([SharedRootBuildCache, subpath], "/");
         /* Where to cache */
-        _hostPaths.compilerCache = join([SharedRootBase, "ccache"], "/");
+        _hostPaths.compilerCache = join([SharedRootCcacheCache], "/");
         /* Where to save binaries */
-        _hostPaths.pkgCache = join([SharedRootBase, "pkgCache"], "/");
+        _hostPaths.pkgCache = join([SharedRootPkgCacheCache], "/");
         /* Where is the recipe..? */
         _hostPaths.recipe = path.dirName.absolutePath.buildNormalizedPath;
         /* And where is the rootfs? */
-        _hostPaths.rootfs = join([SharedRootBase, "root", subpath], "/");
+        _hostPaths.rootfs = join([SharedRootRootCache, subpath], "/");
         /* Unconfined recipe tree? */
         _unconfinedRecipe = join([SharedRootBase, "recipe", subpath], "/");
     }
@@ -150,7 +166,7 @@ public final class BuildJob
         ], "/");
     }
 
-    /** 
+    /**
      * Extra deps
      */
     @property void extraDeps(string[] deps) @safe

--- a/source/boulder/cli/deletecache_command.d
+++ b/source/boulder/cli/deletecache_command.d
@@ -16,7 +16,10 @@
 module boulder.cli.deletecache_command;
 
 public import moss.core.cli;
+import boulder.buildjob : SharedRootArtefactsCache, SharedRootBuildCache,
+    SharedRootCcacheCache, SharedRootPkgCacheCache, SharedRootRootCache;
 import boulder.cli : BoulderCLI;
+import boulder.upstreamcache : SharedRootUpstreamsCache;
 import core.sys.posix.unistd : geteuid;
 import moss.core : ExitStatus;
 import moss.core.sizing : formattedSize;
@@ -59,19 +62,13 @@ public struct DeleteCacheCommand
             return ExitStatus.Failure;
         }
 
-        /* FIXME: These paths should be easily importable from boulder */
-        immutable static artefacts = "/var/cache/boulder/artefacts";
-        immutable static build = "/var/cache/boulder/build";
-        immutable static ccache = "/var/cache/boulder/ccache";
-        immutable static pkgCache = "/var/cache/boulder/pkgCache";
-        immutable static root = "/var/cache/boulder/root";
-        immutable static upstreams = "/var/cache/boulder/upstreams";
-
         /* Print out disk usage and return if sizes is requested */
         if (sizes == true)
         {
             string[] cachePaths = [
-                artefacts, build, ccache, pkgCache, root, upstreams,
+                SharedRootArtefactsCache, SharedRootBuildCache,
+                SharedRootCcacheCache, SharedRootPkgCacheCache,
+                SharedRootRootCache, SharedRootUpstreamsCache,
             ];
             double totalSize = 0;
             foreach (string path; cachePaths)
@@ -85,7 +82,7 @@ public struct DeleteCacheCommand
         }
 
         /* Figure out what paths we're nuking */
-        string[] nukeCachePaths = [root];
+        string[] nukeCachePaths = [SharedRootRootCache];
         if (deleteAll == true)
         {
             delArtefacts = true;
@@ -95,15 +92,15 @@ public struct DeleteCacheCommand
             delUpstreams = true;
         }
         if (delArtefacts == true)
-            nukeCachePaths ~= artefacts;
+            nukeCachePaths ~= SharedRootArtefactsCache;
         if (delBuild == true)
-            nukeCachePaths ~= build;
+            nukeCachePaths ~= SharedRootBuildCache;
         if (delCcache == true)
-            nukeCachePaths ~= ccache;
+            nukeCachePaths ~= SharedRootCcacheCache;
         if (delPkgCache == true)
-            nukeCachePaths ~= pkgCache;
+            nukeCachePaths ~= SharedRootPkgCacheCache;
         if (delUpstreams == true)
-            nukeCachePaths ~= upstreams;
+            nukeCachePaths ~= SharedRootUpstreamsCache;
 
         /* Nuke the paths */
         double totalSize = 0;

--- a/source/boulder/upstreamcache.d
+++ b/source/boulder/upstreamcache.d
@@ -29,6 +29,11 @@ public import moss.format.source.upstream_definition;
 import std.sumtype : tryMatch;
 
 /**
+ * Base of all directories
+ */
+public static immutable(string) SharedRootUpstreamsCache = "/var/cache/boulder/upstreams";
+
+/**
  * The UpstreamCache provides persistent paths and
  * deduplication facilities to permit retention of
  * hash-indexed downloads across multiple builds.
@@ -50,7 +55,8 @@ public final class UpstreamCache
     void constructDirs()
     {
         auto paths = [
-            rootDirectory, stagingDirectory, gitDirectory, plainDirectory
+            SharedRootUpstreamsCache, stagingDirectory, gitDirectory,
+            plainDirectory
         ];
         foreach (p; paths)
         {
@@ -66,7 +72,7 @@ public final class UpstreamCache
         return finalPath(def).exists;
     }
 
-    /** 
+    /**
      *  Promote from staging to real. This is where Git sources fetch their
      *  submodules.
      */
@@ -142,7 +148,7 @@ public final class UpstreamCache
     /**
      * Reset the non-bare Git repository in def's **final path** to the
      * requested ref.
-     * 
+     *
      * Note that its submodules will also be fetched and checked out to their
      * corresponding ref.
      *
@@ -175,7 +181,7 @@ public final class UpstreamCache
      * Given an UpstreamDefinition and a Git ref, check if the ref is present in
      * the upstream source's mirror clone in the **staging directory**. Always
      * returns false if the source's staging directory doesn't exist.
-     * 
+     *
      * Note that it does not actually verify that ref exists as a commit. It
      * only verifies that there is an object in the database corresponding to
      * the SHA1 provided. However, it's enough for our purposes, since
@@ -289,26 +295,26 @@ public final class UpstreamCache
     }
 
 private:
-
-    /**
-     * Base of all directories
-     */
-    static immutable(string) rootDirectory = "/var/cache/boulder/upstreams";
-
     /**
      * Staging downloads that might be wonky.
      */
-    static immutable(string) stagingDirectory = join([rootDirectory, "staging"], "/");
+    static immutable(string) stagingDirectory = join([
+        SharedRootUpstreamsCache, "staging"
+    ], "/");
 
     /**
      * Git clones
      */
-    static immutable(string) gitDirectory = join([rootDirectory, "git"], "/");
+    static immutable(string) gitDirectory = join([
+        SharedRootUpstreamsCache, "git"
+    ], "/");
 
     /**
      * Plain downloads
      */
-    static immutable(string) plainDirectory = join([rootDirectory, "fetched"], "/");
+    static immutable(string) plainDirectory = join([
+        SharedRootUpstreamsCache, "fetched"
+    ], "/");
 
     /**
      * Converts and normalizes a URI (in our use case, an HTTP(S) Git remote
@@ -379,5 +385,4 @@ private:
             }
         }
     }
-
 }


### PR DESCRIPTION
Previously the cache paths were constructed when creating a buildjob. This is not necessary as the base paths are static.

This also allows to resolve a FIXME in `cli/delete_cache` to import the cache paths from boulder instead of redeclaring them.