### PR TITLE
base.yml: Set CGO flags

### DIFF
--- a/data/macros/arch/base.yml
+++ b/data/macros/arch/base.yml
@@ -53,8 +53,11 @@ actions              :
             set -x
             TERM="dumb"; export TERM
             CFLAGS="%(cflags)"; export CFLAGS
+            CGO_CFLAGS="%(cflags)"; export CGO_CFLAGS
             CXXFLAGS="%(cxxflags)"; export CXXFLAGS
+            CGO_CXXFLAGS="%(cxxflags)"; export CGO_CXXFLAGS
             LDFLAGS="%(ldflags)"; export LDFLAGS
+            CGO_LDFLAGS="%(ldflags)"; export CGO_LDFLAGS
             CC="%(cc)"; export CC
             CXX="%(cxx)"; export CXX
             CPP="%(cpp)"; export CPP


### PR DESCRIPTION
These are used when compiling cgo packages.

Couple of notes:

- Why `TERM="dumb"; export TERM` instead of just `export TERM="dumb"`? I thought it's because `set -x` doesn't print the expanded variable but it does, according to a test.
- CGO flags aren't inherited from standard flags, so these are necessary.
- In the future we may have more flags: Fortran, Rust, Zig and whatnot. IMO it's wise to split the base script into multiple and single-scoped portions.