### PR TITLE
boulder/controller: Return ExitStatus from StageResult

### DIFF
--- a/source/boulder/cli/build_command.d
+++ b/source/boulder/cli/build_command.d
@@ -88,11 +88,12 @@ public struct BuildControlCommand
             return ExitStatus.Failure;
         }
 
+        ExitStatus res;
         foreach (recipe; argv)
         {
-            controller.build(recipe);
+            res = controller.build(recipe);
         }
-        return ExitStatus.Success;
+        return res;
     }
 
     /** Select an alternative output location than the current working directory */


### PR DESCRIPTION
Previously `controller.build()` would not return a result meaning that `boulder build` would always exit with code 0, even if the build failed.

Now, the build subcommand will exit with the code returned by controller.build.

Resolves #34.