### PR TITLE
boulder/upstreamcache: Make copyDir parallel

### DIFF
--- a/source/boulder/upstreamcache.d
+++ b/source/boulder/upstreamcache.d
@@ -354,8 +354,10 @@ private:
      */
     void copyDir(string inDir, string outDir)
     {
+        import std.array : array;
         import std.file;
         import std.path;
+        import std.parallelism : parallel;
         import std.typecons : Yes;
 
         if (!exists(outDir))
@@ -367,7 +369,7 @@ private:
             enforce(outDir.isDir, format!"Destination path %s is not a folder."(outDir));
         }
 
-        foreach (entry; dirEntries(inDir, SpanMode.shallow, false))
+        foreach (entry; parallel(dirEntries(inDir, SpanMode.shallow, false).array))
         {
             auto fileName = baseName(entry.name);
             auto destName = buildPath(outDir, fileName);


### PR DESCRIPTION
Test Case (Avg. 5 runs)

Source:
 - git|https://sourceware.org/git/glibc.git : 590d0e089b06f158ded713f5e5600eaa66dcea44

Before: 687ms
After:  133ms

Tested on an NVME SSD.