### PR TITLE
mason/emitter: emit pkgs in parallel

### DIFF
--- a/source/mason/build/emitter.d
+++ b/source/mason/build/emitter.d
@@ -69,8 +69,13 @@ public class BuildEmitter
     void emit(const(string) outputDirectory, Analyser analyser) @system
     {
         import std.algorithm : each;
+        import std.parallelism : parallel;
 
-        packages.values.each!((p) => emitPackage(outputDirectory, p, analyser));
+        foreach(p; packages.values.parallel)
+        {
+            emitPackage(outputDirectory, p, analyser);
+        }
+
         binaryManifest.write();
         jsonManifest.write();
     }


### PR DESCRIPTION
Depends on https://github.com/serpent-os/moss-deps/pull/4

Quick n' Dirty Benchmarks
glibc : 28s -> 8s
curl  : 1.17s -> 668ms
nano  : 451ms -> 311ms

Sub task of #41.