### PR TITLE
cli/delete_cache: getSizeDir improvements

### DIFF
--- a/source/boulder/cli/deletecache_command.d
+++ b/source/boulder/cli/deletecache_command.d
@@ -187,7 +187,7 @@ auto getSizeDir(in string path) @trusted
 {
     import core.atomic : atomicOp;
     import std.array : array;
-    import std.file : dirEntries, FileException, getSize, isFile, SpanMode;
+    import std.file : attrIsFile, dirEntries, FileException, getSize, SpanMode;
     import std.parallelism : parallel;
 
     /* Use a global var and increment it with an atomicOp to
@@ -198,7 +198,7 @@ auto getSizeDir(in string path) @trusted
     {
         foreach (name; parallel(dirEntries(path, SpanMode.breadth, false).array))
         {
-            if (name.isFile)
+            if (attrIsFile(name.linkAttributes))
             {
                 atomicOp!"+="(totalSize, getSize(name));
             }


### PR DESCRIPTION
- Make getSizeDir report a size much closer to what `du` reports
- Avoid a race condition by using a global counter to ensure a consistent result

Read commits for details.