### PR TITLE
boulder&macros: Initial support for D builds

### DIFF
--- a/data/macros/arch/base.yml
+++ b/data/macros/arch/base.yml
@@ -38,6 +38,7 @@ definitions:
     - cpp            : "%(compiler_cpp)"
     - objcpp         : "%(compiler_objcpp)"
     - objcxxcpp      : "%(compiler_objcxxcpp)"
+    - d              : "%(compiler_d)"
     - ar             : "%(compiler_ar)"
     - ld             : "%(compiler_ld)"
     - objcopy        : "%(compiler_objcopy)"
@@ -64,6 +65,7 @@ actions              :
             CGO_CXXFLAGS="%(cxxflags)"; export CGO_CXXFLAGS
             LDFLAGS="%(ldflags)"; export LDFLAGS
             CGO_LDFLAGS="%(ldflags) -Wl,--no-gc-sections"; export CGO_LDFLAGS
+            DFLAGS="%(dflags)"; export DFLAGS
             CC="%(cc)"; export CC
             CXX="%(cxx)"; export CXX
             OBJC="%(objc)"; export OBJC
@@ -286,14 +288,17 @@ flags               :
         c         : "-pipe -Wformat -Wformat-security -Wno-error -fPIC"
         cxx       : "-pipe -Wformat -Wformat-security -Wno-error -fPIC"
         ld        : "-Wl,-O2,--gc-sections"
+        d         : "-release -Hkeep-all-bodies -relocation-model=pic -wi"
 
     - omit-frame-pointer:
         c         : "-fomit-frame-pointer -momit-leaf-frame-pointer"
         cxx       : "-fomit-frame-pointer -momit-leaf-frame-pointer"
+        d         : "-frame-pointer=none"
 
     - no-omit-frame-pointer:
         c         : "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
         cxx       : "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
+        d         : "-frame-pointer=all"
 
     # Toggle bindnow (ON)
     - bindnow:
@@ -347,28 +352,35 @@ flags               :
     - optimize-generic:
         c         : "-O2"
         cxx       : "-O2"
+        d         : "-O2"
 
     # Optimize for size (OFF)
     - optimize-size:
         c     : "-Os"
         cxx   : "-Os"
+        d     : "-Os"
 
     # Optimize for speed (OFF)
     - optimize-speed:
         c         : "-O3"
         cxx       : "-O3"
+        d         : "-O3"
 
     # Enable LTO optimisations (OFF)
     - lto-full:
         c         : "-flto"
         cxx       : "-flto"
         ld        : "-flto"
+        llvm:
+            d         : "-flto=full"
+
 
     # Enable Thin-LTO optimisations (OFF)
     - lto-thin:
         llvm:
             c         : "-flto=thin"
             cxx       : "-flto=thin"
+            d         : "-flto=thin"
             ld        : "-flto=thin"
 
     # Enable LTOextra optimisations (OFF)
@@ -406,6 +418,7 @@ flags               :
         llvm:
             c     : "-Xclang -mllvm -Xclang -polly -Xclang -mllvm -Xclang -polly-vectorizer=stripmine"
             cxx   : "-Xclang -mllvm -Xclang -polly -Xclang -mllvm -Xclang -polly-vectorizer=stripmine"
+            d     : "-polly -polly-vectorizer=stripmine"
 
     # Toggle options you want to use with llvm-bolt (OFF)
     - bolt:
@@ -426,14 +439,17 @@ flags               :
         llvm:
             c         : "-gline-tables-only -fasynchronous-unwind-tables"
             cxx       : "-gline-tables-only -fasynchronous-unwind-tables"
+            d         : "-gline-tables-only -gc"
 
     # Toggle debug-std optimisations (ON)
     - debug-std:
         c         : "-g -feliminate-unused-debug-types -fasynchronous-unwind-tables"
         cxx       : "-g -feliminate-unused-debug-types -fasynchronous-unwind-tables"
+        d         : "-g -gc -d-debug"
 
     # Toggle fast math (OFF)
     - math:
+        d         : "-ffast-math -fp-contract=fast"
         gnu:
             c         : "-fno-math-errno -fno-trapping-math"
             cxx       : "-fno-math-errno -fno-trapping-math"
@@ -445,6 +461,7 @@ flags               :
     - noplt:
         c         : "-fno-plt"
         cxx       : "-fno-plt"
+        d         : "-fno-plt"
 
     # Toggle -fno-semantic-interposition (OFF)
     - nosemantic:
@@ -486,6 +503,7 @@ flags               :
     - visibility-hidden:
         c          : "-fvisibility=hidden"
         cxx        : "-fvisibility-inlines-hidden -fvisibility=hidden"
+        d          : "-fvisibility=hidden"
 
     # Toggle visibility inlines hidden (OFF)
     - visibility-inline:

--- a/data/macros/arch/x86_64.yml
+++ b/data/macros/arch/x86_64.yml
@@ -8,6 +8,7 @@ definitions:
     - cc             : "%(compiler_c)"
     - cxx            : "%(compiler_cxx)"
     - cpp            : "%(compiler_cpp)"
+    - d              : "%(compiler_d)"
     - march          : x86-64-v2
     - mtune          : ivybridge
 
@@ -17,3 +18,4 @@ flags:
     - architecture:
         c         : "-march=x86-64-v2 -mtune=ivybridge"
         cxx       : "-march=x86-64-v2 -mtune=ivybridge"
+        d         : "-mcpu=x86-64-v2"

--- a/source/mason/build/profile.d
+++ b/source/mason/build/profile.d
@@ -299,6 +299,7 @@ public:
             sbuilder.addDefinition("compiler_cpp", "clang -E -");
             sbuilder.addDefinition("compiler_objcpp", "clang -E -");
             sbuilder.addDefinition("compiler_objcxxcpp", "clang++ -E");
+            sbuilder.addDefinition("compiler_d", "ldc2");
             sbuilder.addDefinition("compiler_ar", "llvm-ar");
             sbuilder.addDefinition("compiler_ld", "ld.lld");
             sbuilder.addDefinition("compiler_objcopy", "llvm-objcopy");
@@ -316,6 +317,7 @@ public:
             sbuilder.addDefinition("compiler_cpp", "gcc -E");
             sbuilder.addDefinition("compiler_objcpp", "gcc -E");
             sbuilder.addDefinition("compiler_objcxxcpp", "g++ -E");
+            sbuilder.addDefinition("compiler_d", "ldc2"); /* FIXME: GDC */
             sbuilder.addDefinition("compiler_ar", "gcc-ar");
             sbuilder.addDefinition("compiler_ld", "ld.bfd");
             sbuilder.addDefinition("compiler_objcopy", "objcopy");
@@ -418,10 +420,12 @@ private:
         auto flagset = sbuilder.buildFlags();
         auto cflags = fixupFlags(flagset.map!((f) => f.cflags(toolchain)));
         auto cxxflags = fixupFlags(flagset.map!((f) => f.cxxflags(toolchain)));
+        auto dflags = fixupFlags(flagset.map!((f) => f.dflags(toolchain)));
         auto ldflags = fixupFlags(flagset.map!((f) => f.ldflags(toolchain)));
 
         sbuilder.addDefinition("cflags", cflags);
         sbuilder.addDefinition("cxxflags", cxxflags);
+        sbuilder.addDefinition("dflags", dflags);
         sbuilder.addDefinition("ldflags", ldflags);
     }
 


### PR DESCRIPTION
Currently things are hardcoded to support the ldc2 compiler for both the `llvm` and `gnu` toolchain. In the future, we'll switch to using the GDC compiler when using the `gcc` toolchain once it is packaged.

It is unlikely we will support the reference compiler (dmd) OOTB.