### PR TITLE
cli/build: Ensure we return ExitStatus consistently

### DIFF
--- a/source/boulder/cli/build_command.d
+++ b/source/boulder/cli/build_command.d
@@ -82,6 +82,12 @@ public struct BuildControlCommand
             return ExitStatus.Failure;
         }
 
+        if (argv.length > 1)
+        {
+            error(format!"Unexpected number of arguments, got %s. Expected one recipe file."(argv.length));
+            return ExitStatus.Failure;
+        }
+
         /* When no recipes are specified, build stone.yml recipe in current directory if it exists */
         if (argv == null && "stone.yml".exists)
         {
@@ -90,10 +96,7 @@ public struct BuildControlCommand
         }
         else
         {
-            foreach (recipe; argv)
-            {
-                res = controller.build(recipe);
-            }
+            res = controller.build(argv[0]);
         }
         return res;
     }

--- a/source/boulder/cli/build_command.d
+++ b/source/boulder/cli/build_command.d
@@ -54,6 +54,7 @@ public struct BuildControlCommand
     {
         immutable useDebug = this.findAncestor!BoulderCLI.debugMode;
         globalLogLevel = useDebug ? LogLevel.trace : LogLevel.info;
+        ExitStatus res;
 
         immutable profile = this.findAncestor!BoulderCLI.profile;
         immutable configDir = this.findAncestor!BoulderCLI.configDir;
@@ -74,13 +75,6 @@ public struct BuildControlCommand
         auto controller = new Controller(outputDirectory, architecture,
                 !unconfined, profile, compilerCache, configDir);
 
-        /* When no recipes are specified, build stone.yml recipe in current directory if it exists */
-        if (argv == null && "stone.yml".exists)
-        {
-            trace("No recipe specified, building stone.yml recipe found in current directory");
-            controller.build("stone.yml");
-        }
-
         /* Require a recipe to continue */
         if (argv == null && !"stone.yml".exists)
         {
@@ -88,10 +82,18 @@ public struct BuildControlCommand
             return ExitStatus.Failure;
         }
 
-        ExitStatus res;
-        foreach (recipe; argv)
+        /* When no recipes are specified, build stone.yml recipe in current directory if it exists */
+        if (argv == null && "stone.yml".exists)
         {
-            res = controller.build(recipe);
+            trace("No recipe specified, building stone.yml recipe found in current directory");
+            res = controller.build("stone.yml");
+        }
+        else
+        {
+            foreach (recipe; argv)
+            {
+                res = controller.build(recipe);
+            }
         }
         return res;
     }


### PR DESCRIPTION
Fixes boulder exiting with code 1 after a successful build if a recipe location wasn't passed to args and boulder just built the stone.yml recipe found in the current location.