### PR TITLE
mason/build: export objective c environment variables

### DIFF
--- a/data/macros/arch/base.yml
+++ b/data/macros/arch/base.yml
@@ -33,7 +33,11 @@ definitions:
     # Must be set for CC/CXX/CPP to work
     - cc             : "%(compiler_c)"
     - cxx            : "%(compiler_cxx)"
+    - objc           : "%(compiler_objc)"
+    - objcxx         : "%(compiler_objcxx)"
     - cpp            : "%(compiler_cpp)"
+    - objcpp         : "%(compiler_objcpp)"
+    - objcxxcpp      : "%(compiler_objcxxcpp)"
     - ar             : "%(compiler_ar)"
     - ld             : "%(compiler_ld)"
     - objcopy        : "%(compiler_objcopy)"
@@ -62,7 +66,11 @@ actions              :
             CGO_LDFLAGS="%(ldflags)"; export CGO_LDFLAGS
             CC="%(cc)"; export CC
             CXX="%(cxx)"; export CXX
+            OBJC="%(objc)"; export OBJC
+            OBJCXX="%(objcxx)"; export OBJCXX
             CPP="%(cpp)"; export CPP
+            OBJCPP="%(objcpp)"; export OBJCPP
+            OBJCXXCPP="%(objcxxcpp)"; export OBJCXXCPP
             AR="%(ar)"; export AR
             LD="%(ld)"; export LD
             OBJCOPY="%(objcopy)"; export OBJCOPY

--- a/source/mason/build/profile.d
+++ b/source/mason/build/profile.d
@@ -294,7 +294,11 @@ public:
         {
             sbuilder.addDefinition("compiler_c", "clang");
             sbuilder.addDefinition("compiler_cxx", "clang++");
-            sbuilder.addDefinition("compiler_cpp", "clang-cpp");
+            sbuilder.addDefinition("compiler_objc", "clang");
+            sbuilder.addDefinition("compiler_objcxx", "clang++");
+            sbuilder.addDefinition("compiler_cpp", "clang -E");
+            sbuilder.addDefinition("compiler_objcpp", "clang -E");
+            sbuilder.addDefinition("compiler_objcxxcpp", "clang++ -E");
             sbuilder.addDefinition("compiler_ar", "llvm-ar");
             sbuilder.addDefinition("compiler_ld", "ld.lld");
             sbuilder.addDefinition("compiler_objcopy", "llvm-objcopy");
@@ -307,7 +311,11 @@ public:
         {
             sbuilder.addDefinition("compiler_c", "gcc");
             sbuilder.addDefinition("compiler_cxx", "g++");
+            sbuilder.addDefinition("compiler_objc", "gcc");
+            sbuilder.addDefinition("compiler_objcxx", "g++");
             sbuilder.addDefinition("compiler_cpp", "gcc -E");
+            sbuilder.addDefinition("compiler_objcpp", "gcc -E");
+            sbuilder.addDefinition("compiler_objcxxcpp", "g++ -E");
             sbuilder.addDefinition("compiler_ar", "gcc-ar");
             sbuilder.addDefinition("compiler_ld", "ld.bfd");
             sbuilder.addDefinition("compiler_objcopy", "objcopy");


### PR DESCRIPTION
Allows build systems (`autoconf` particularly) to correctly detect Objective C/C++ compilers and preprocessors correctly.
