### PR TITLE
boulder/controller: manually catch and notify promote failure

### DIFF
--- a/source/boulder/controller.d
+++ b/source/boulder/controller.d
@@ -393,7 +393,14 @@ private:
         }
 
         /* Promote the source now */
-        upstreamCache.promote(ud);
+        try
+        {
+            upstreamCache.promote(ud);
+        }
+        catch (Exception e)
+        {
+            onFetchFail(f, format!"Failed to promote source, reason: %s"(e.msg));
+        }
     }
 
     /**


### PR DESCRIPTION
Ref: #80.

Previously, any exception thrown in the `upstreamcache.promote` method would simply cause the `boulder` process to hang. Not quite friendly!

Therefore, we wrap the `promote` method in a `try-catch` block and manually call `onFetchFail` with the appropriate failure message when a package fails to get promoted.
