### PR TITLE
Don't color output if stdin is no TTY

### DIFF
--- a/source/boulder/main.d
+++ b/source/boulder/main.d
@@ -20,6 +20,7 @@
 module main;
 
 import boulder.cli;
+import core.sys.posix.unistd;
 import mason.cli;
 import moss.core.logger;
 import std.path : baseName;
@@ -52,7 +53,14 @@ int masonMain(string[] args)
 
 int main(string[] args)
 {
-    configureLogger(ColorLoggerFlags.Color | ColorLoggerFlags.Timestamps);
+    if (isatty(0) && isatty(1))
+    {
+        configureLogger(ColorLoggerFlags.Color | ColorLoggerFlags.Timestamps);
+    }
+    else
+    {
+        configureLogger(ColorLoggerFlags.Timestamps);
+    }
 
     auto programName = args[0].baseName;
     switch (programName)

--- a/source/mason/cli/build_command.d
+++ b/source/mason/cli/build_command.d
@@ -16,6 +16,7 @@
 module mason.cli.build_command;
 
 public import moss.core.cli;
+import core.sys.posix.unistd;
 import mason.build.context;
 import mason.build.controller;
 import mason.cli : MasonCLI;
@@ -53,7 +54,14 @@ public struct BuildCommand
     @CommandEntry() int run(ref string[] argv)
     {
         /* configureLogger resets the globalLogLevel to LogLevel.info */
-        configureLogger(ColorLoggerFlags.Color | ColorLoggerFlags.Timestamps);
+        if (isatty(0) && isatty(1))
+        {
+            configureLogger(ColorLoggerFlags.Color | ColorLoggerFlags.Timestamps);
+        }
+        else
+        {
+            configureLogger(ColorLoggerFlags.Timestamps);
+        }
 
         immutable useDebug = this.findAncestor!MasonCLI.debugMode;
         globalLogLevel = useDebug ? LogLevel.trace : LogLevel.info;


### PR DESCRIPTION
Fixes #82, at least in part. Needs to be done in other components like moss as well.