### PR TITLE
drafter: Always convert the name to lower case

### DIFF
--- a/source/drafter/metadata/basic.d
+++ b/source/drafter/metadata/basic.d
@@ -17,8 +17,9 @@ module drafter.metadata.basic;
 
 import std.typecons : Nullable;
 import moss.format.source.source_definition;
-import std.regex;
 import std.path : baseName, dirName;
+import std.regex;
+import std.uni : toLower;
 
 /**
  * Standard/basic version detection
@@ -51,7 +52,7 @@ public struct BasicMetadata
         }
 
         auto sd = SourceDefinition();
-        sd.name = m[BasicIndex.Name];
+        sd.name = m[BasicIndex.Name].toLower;
         sd.versionIdentifier = m[BasicIndex.Version];
         sd.homepage = uri.dirName;
         return Nullable!(SourceDefinition, SourceDefinition.init)(sd);

--- a/source/drafter/metadata/github.d
+++ b/source/drafter/metadata/github.d
@@ -19,6 +19,7 @@ import std.typecons : Nullable;
 import moss.format.source.source_definition;
 import std.regex;
 import std.string : format;
+import std.uni : toLower;
 
 /**
  * Github automatically generated downloads
@@ -67,7 +68,7 @@ public struct GithubMetadata
             auto sd = SourceDefinition();
             sd.homepage = format!"https://github.com/%s/%s"(m[GithubIndex.Owner],
                     m[GithubIndex.Project]);
-            sd.name = m[GithubIndex.Project];
+            sd.name = m[GithubIndex.Project].toLower;
             sd.versionIdentifier = m[GithubIndex.Version];
             return Nullable!(SourceDefinition, SourceDefinition.init)(sd);
         }


### PR DESCRIPTION
Capitalization in package names is discouraged and won't be accepted in the future.