### PR TITLE
boulder/cli/build: Setup a inhibitor lock during build

### DIFF
--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Install deps
       run: |
-        sudo apt-get install git libcurl4-openssl-dev libgit2-dev liblmdb-dev libxxhash-dev libzstd-dev
+        sudo apt-get install git libcurl4-openssl-dev libgit2-dev liblmdb-dev libxxhash-dev libzstd-dev libdbus-1-dev
 
     - name: Build & Test
       run: |

--- a/source/boulder/cli/build_command.d
+++ b/source/boulder/cli/build_command.d
@@ -89,6 +89,9 @@ public struct BuildControlCommand
             return ExitStatus.Failure;
         }
 
+        // Create a login1 inhibitor lock to prevent the system from going down during a build.
+        auto lock = inhibit("shutdown:sleep:idle", "boulder", "build in progress", "block");
+
         /* When no recipes are specified, build stone.yml recipe in current directory if it exists */
         if (argv == null && "stone.yml".exists)
         {


### PR DESCRIPTION
https://www.freedesktop.org/wiki/Software/systemd/inhibit/

NB. Currently doesn't work on GNOME as GNOME has it's own session inhibitor API and doesn't respect the login1 locks. `systemctl poweroff` will work on GNOME however.