### PR TITLE
data/default-x86_64.conf: collections -> repos

### DIFF
--- a/data/default-x86_64.conf
+++ b/data/default-x86_64.conf
@@ -3,7 +3,7 @@
 
         - volatile:
             uri: "https://dev.serpentos.com/volatile/x86_64/stone.index"
-            description: "Volatile binary collection"
+            description: "Volatile moss repo"
             priority: 0
 
 - local-x86_64:
@@ -11,10 +11,10 @@
 
         - volatile:
             uri: "https://dev.serpentos.com/volatile/x86_64/stone.index"
-            description: "Volatile binary collection"
+            description: "Volatile moss repo"
             priority: 0
 
         - local:
-            uri: "file:///var/cache/boulder/collections/local-x86_64/stone.index"
-            description: "Local development binary collection"
+            uri: "file:///var/cache/boulder/repos/local-x86_64/stone.index"
+            description: "Local development moss repo"
             priority: 10


### PR DESCRIPTION
This updates default user-facing terminology to be in line with moss-rs.